### PR TITLE
Display better error message while parsing JSON

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.trailingComma": "es5"
+}

--- a/app/src/views/items/EditItem.vue
+++ b/app/src/views/items/EditItem.vue
@@ -8,6 +8,9 @@
       </p>
       <textarea ref="textAreaRef" />
 
+      <div class="alert alert-danger rounded-0" role="alert" v-if="!!errorMsg">
+        {{ errorMsg }}
+      </div>
       <br />
       <br />
       <br />
@@ -81,9 +84,10 @@ import * as CodeMirror from "codemirror";
 import { linter } from "@codemirror/lint";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
+import parseJson from "parse-json";
 
 import { useRoute, useRouter } from "vue-router";
-import { computed, inject, onMounted, reactive, ref, watch } from "vue";
+import { inject, onMounted, reactive, ref, watch } from "vue";
 
 import { getTable } from "@/services/table";
 import { getItem, updateItem } from "@/services/item";
@@ -93,6 +97,7 @@ export default {
     let cm;
     const item = ref("");
     const editItem = ref("");
+    const errorMsg = ref("");
 
     const isValid = ref(true);
     const hasKeyChanged = ref(false);
@@ -151,16 +156,17 @@ export default {
       isValid.value = false;
 
       try {
-        const validItem = JSON.parse(edited);
-        const originalItem = JSON.parse(original);
-
+        const validItem = parseJson(edited);
+        const originalItem = parseJson(original);
         isValid.value = true;
+        errorMsg.value = "";
         hasKeyChanged.value = false;
 
         Object.keys(route.query).forEach((key) => {
           hasKeyChanged.value ||= originalItem[key] !== validItem[key];
         });
       } catch (error) {
+        errorMsg.value = error.message;
         isValid.value = false;
       }
     });
@@ -227,6 +233,7 @@ export default {
       toastRef,
       cancel,
       save,
+      errorMsg,
     };
   },
 };

--- a/app/src/views/items/EditItem.vue
+++ b/app/src/views/items/EditItem.vue
@@ -84,7 +84,6 @@ import * as CodeMirror from "codemirror";
 import { linter } from "@codemirror/lint";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
-import parseJson from "parse-json";
 
 import { useRoute, useRouter } from "vue-router";
 import { inject, onMounted, reactive, ref, watch } from "vue";
@@ -156,8 +155,8 @@ export default {
       isValid.value = false;
 
       try {
-        const validItem = parseJson(edited);
-        const originalItem = parseJson(original);
+        const validItem = JSON.parse(edited);
+        const originalItem = JSON.parse(original);
         isValid.value = true;
         errorMsg.value = "";
         hasKeyChanged.value = false;


### PR DESCRIPTION
### Description
Errors are really helpful for devs. Having not known where the issue is not a better DX. Although the code mirror points out where the error is in the line, it has poor visibility and the disabled state in Save button has poor visibility as well.

### Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

<img width="746" alt="Screen Shot 2022-10-25 at 11 28 52 PM" src="https://user-images.githubusercontent.com/11685953/197844823-edb405f3-bb86-43d1-82d7-871c240897ae.png">

### Known issue
The line number is not accurate. Since it's stringifying everything in one line, the line number is not accurate. Another PR could be to divide by number of double quotes, comma and slash /n s to provide near line number or a better approach.

Another PR could be similar implementation for Create Page by another contributor.

Let's discuss more on thread about this feature.