### PR TITLE
chore: procedural -> object oriented to support multiple DynamoDB instance 

### DIFF
--- a/server/src/config/aws.js
+++ b/server/src/config/aws.js
@@ -2,13 +2,13 @@ import config from "../constants/config";
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 
-class AWS {
-  static initializeFromDynamoDB({ dynamodb }) {
+export class AWS {
+  initializeFromDynamoDB({ dynamodb }) {
     this.dynamodb = dynamodb;
     this.document = DynamoDBDocument.from(this.dynamodb);
   }
 
-  static initialize({
+  initialize({
     AWS_REGION = config.aws.region,
     AWS_ENDPOINT = config.aws.endpoint,
     AWS_ACCESS_KEY_ID = config.aws.credentials.accessKeyId,
@@ -36,4 +36,4 @@ class AWS {
   }
 }
 
-export default AWS;
+export default new AWS();

--- a/server/src/controllers/item.controller.js
+++ b/server/src/controllers/item.controller.js
@@ -1,6 +1,8 @@
 import { OPERATIONS } from "../constants/dynamodb";
 import { isPartialMatchWith } from "../utils/object";
-import * as ItemService from "../services/item.service";
+import ItemServiceProvider from "../services/item.service";
+
+const ItemService = new ItemServiceProvider();
 
 export async function get(req, res, next) {
   try {

--- a/server/src/controllers/table.controller.js
+++ b/server/src/controllers/table.controller.js
@@ -1,4 +1,6 @@
-import * as TableService from "../services/table.service";
+import TableServiceProvider from "../services/table.service";
+
+const TableService = new TableServiceProvider();
 
 export async function index(_req, res, next) {
   try {

--- a/server/src/services/item.service.js
+++ b/server/src/services/item.service.js
@@ -1,167 +1,173 @@
 import AWS from "../config/aws";
 import { pick } from "../utils/object";
 
-// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html
-// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html
-/**
- *
- * @param {*} operation
- * @param {*} tableName
- * @param {*} conditions
- * @returns
- */
-export async function fetch(operation, tableName, conditions) {
-  const params = {
-    TableName: tableName,
-    ...conditions,
-  };
-
-  const items = [];
-  let scannedCount = 0;
-
-  // Slice
-  let intermediateExclusiveStartKey = params.ExclusiveStartKey;
-
-  do {
-    const response = await AWS.document[operation](params); // AWS.document.scan(...), AWS.document.query(...)
-    scannedCount += response.ScannedCount;
-
-    items.push(...response.Items);
-    params.ExclusiveStartKey = response.LastEvaluatedKey;
-
-    // Slice
-    intermediateExclusiveStartKey ||= response.LastEvaluatedKey;
-
-    if (items.length >= params.Limit) break;
-  } while (params.ExclusiveStartKey);
-
-  /* Slice
-   * eg:
-   * Limit = 10
-   * intermediateExclusiveStartKey = g
-   * items = [...[a,b,c,d,e,f,g], ...[h,i,j,k,l]]
-   * slice = [a,b,c,d,e,f,g,h,i,j]
-   * ExclusiveStartKey = pick(j, Object.keys(g))
-  */
-  const slice = items.slice(0, params.Limit);
-
-  if (items.length > slice.length) {
-    const item = slice.at(-1);
-    const indices = Object.keys(intermediateExclusiveStartKey);
-
-    params.ExclusiveStartKey = pick(item, indices);
+export default class ItemServiceProvider {
+  constructor(_AWS_ = AWS) {
+    this.AWS = _AWS_;
   }
 
-  return {
-    Items: slice,
-    Count: slice.length,
-    ScannedCount: scannedCount,
-    LastEvaluatedKey: params.ExclusiveStartKey,
-  };
-}
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html
+  /**
+   *
+   * @param {*} operation
+   * @param {*} tableName
+   * @param {*} conditions
+   * @returns
+   */
+  async fetch(operation, tableName, conditions) {
+    const params = {
+      TableName: tableName,
+      ...conditions,
+    };
 
-/**
- *
- * @param {*} tableName
- * @param {*} keys
- * @returns
- */
-export async function get(tableName, keys) {
-  const params = {
-    TableName: tableName,
-    Key: keys,
-  };
+    const items = [];
+    let scannedCount = 0;
 
-  const response = await AWS.document.get(params);
+    // Slice
+    let intermediateExclusiveStartKey = params.ExclusiveStartKey;
 
-  return response;
-}
+    do {
+      const response = await this.AWS.document[operation](params); // AWS.document.scan(...), AWS.document.query(...)
+      scannedCount += response.ScannedCount;
 
-/**
- *
- * @param {*} tableName
- * @param {*} items
- * @returns
- */
-export async function destroy(tableName, items) {
-  const response = await AWS.document.batchWrite({
-    RequestItems: {
-      [tableName]: items,
-    },
-  });
+      items.push(...response.Items);
+      params.ExclusiveStartKey = response.LastEvaluatedKey;
 
-  return response;
-}
+      // Slice
+      intermediateExclusiveStartKey ||= response.LastEvaluatedKey;
 
-/**
- *
- * @param {*} tableName
- * @param {*} schema
- * @param {*} data
- * @returns
- */
-export async function create(tableName, schema, body) {
-  const params = {
-    Item: body,
-    TableName: tableName,
-    ConditionExpression: schema
-      .map((key) => `attribute_not_exists(${key})`)
-      .join(" AND "),
-  };
+      if (items.length >= params.Limit) break;
+    } while (params.ExclusiveStartKey);
 
-  const response = await AWS.document.put(params);
+    /* Slice
+     * eg:
+     * Limit = 10
+     * intermediateExclusiveStartKey = g
+     * items = [...[a,b,c,d,e,f,g], ...[h,i,j,k,l]]
+     * slice = [a,b,c,d,e,f,g,h,i,j]
+     * ExclusiveStartKey = pick(j, Object.keys(g))
+    */
+    const slice = items.slice(0, params.Limit);
 
-  return response;
-}
+    if (items.length > slice.length) {
+      const item = slice.at(-1);
+      const indices = Object.keys(intermediateExclusiveStartKey);
 
-/**
- *
- * @param {*} tableName
- * @param {*} schema
- * @param {*} param
- * @returns
- */
-export async function update(tableName, schema, { ref, body }) {
-  const params = {
-    Key: ref,
-    Item: body,
-    TableName: tableName,
-    ConditionExpression: schema
-      .map((key) => `attribute_exists(${key})`)
-      .join(" AND "),
-  };
+      params.ExclusiveStartKey = pick(item, indices);
+    }
 
-  const response = await AWS.document.put(params);
-  return response;
-}
+    return {
+      Items: slice,
+      Count: slice.length,
+      ScannedCount: scannedCount,
+      LastEvaluatedKey: params.ExclusiveStartKey,
+    };
+  }
 
-/**
- * @param {*} tableName
- * @param {*} schema
- * @param {*} param
- * @returns
- */
-export async function transactUpdate(tableName, schema, { ref, body }) {
-  const response = AWS.document.transactWrite({
-    TransactItems: [
-      {
-        Delete: {
-          Key: ref,
-          TableName: tableName,
-        },
+  /**
+   *
+   * @param {*} tableName
+   * @param {*} keys
+   * @returns
+   */
+  async get(tableName, keys) {
+    const params = {
+      TableName: tableName,
+      Key: keys,
+    };
+
+    const response = await this.AWS.document.get(params);
+
+    return response;
+  }
+
+  /**
+   *
+   * @param {*} tableName
+   * @param {*} items
+   * @returns
+   */
+  async destroy(tableName, items) {
+    const response = await this.AWS.document.batchWrite({
+      RequestItems: {
+        [tableName]: items,
       },
-      {
-        Put: {
-          Item: body,
-          TableName: tableName,
-          Key: pick(body, schema),
-          ConditionExpression: schema
-            .map((key) => `attribute_not_exists(${key})`)
-            .join(" AND "),
-        },
-      },
-    ],
-  });
+    });
 
-  return response;
+    return response;
+  }
+
+  /**
+   *
+   * @param {*} tableName
+   * @param {*} schema
+   * @param {*} data
+   * @returns
+   */
+  async create(tableName, schema, body) {
+    const params = {
+      Item: body,
+      TableName: tableName,
+      ConditionExpression: schema
+        .map((key) => `attribute_not_exists(${key})`)
+        .join(" AND "),
+    };
+
+    const response = await this.AWS.document.put(params);
+
+    return response;
+  }
+
+  /**
+   *
+   * @param {*} tableName
+   * @param {*} schema
+   * @param {*} param
+   * @returns
+   */
+  async update(tableName, schema, { ref, body }) {
+    const params = {
+      Key: ref,
+      Item: body,
+      TableName: tableName,
+      ConditionExpression: schema
+        .map((key) => `attribute_exists(${key})`)
+        .join(" AND "),
+    };
+
+    const response = await this.AWS.document.put(params);
+    return response;
+  }
+
+  /**
+   * @param {*} tableName
+   * @param {*} schema
+   * @param {*} param
+   * @returns
+   */
+  async transactUpdate(tableName, schema, { ref, body }) {
+    const response = this.AWS.document.transactWrite({
+      TransactItems: [
+        {
+          Delete: {
+            Key: ref,
+            TableName: tableName,
+          },
+        },
+        {
+          Put: {
+            Item: body,
+            TableName: tableName,
+            Key: pick(body, schema),
+            ConditionExpression: schema
+              .map((key) => `attribute_not_exists(${key})`)
+              .join(" AND "),
+          },
+        },
+      ],
+    });
+
+    return response;
+  }
 }

--- a/server/src/services/table.service.js
+++ b/server/src/services/table.service.js
@@ -1,45 +1,51 @@
 import AWS from "../config/aws";
 
-export async function all() {
-  const tables = [];
-  const params = {};
+export default class TableServiceProvider {
+  constructor(_AWS_ = AWS) {
+    this.AWS = _AWS_;
+  }
 
-  do {
-    const response = await AWS.dynamodb.listTables(params);
-    tables.push(...response.TableNames);
-    params.LastEvaluatedTableName = response.ExclusiveStartTableName;
-  } while (params.LastEvaluatedTableName);
+  async all() {
+    const tables = [];
+    const params = {};
 
-  return tables;
-}
+    do {
+      const response = await this.AWS.dynamodb.listTables(params);
+      tables.push(...response.TableNames);
+      params.LastEvaluatedTableName = response.ExclusiveStartTableName;
+    } while (params.LastEvaluatedTableName);
 
-export async function create(params) {
-  const response = await AWS.dynamodb.createTable(params);
+    return tables;
+  }
 
-  return response;
-}
+  async create(params) {
+    const response = await this.AWS.dynamodb.createTable(params);
 
-export async function describe(tableName) {
-  const response = await AWS.dynamodb.describeTable({
-    TableName: tableName,
-  });
+    return response;
+  }
 
-  return response;
-}
+  async describe(tableName) {
+    const response = await this.AWS.dynamodb.describeTable({
+      TableName: tableName,
+    });
 
-export async function destroy(tableName) {
-  const response = await AWS.dynamodb.deleteTable({
-    TableName: tableName,
-  });
+    return response;
+  }
 
-  return response;
-}
+  async destroy(tableName) {
+    const response = await this.AWS.dynamodb.deleteTable({
+      TableName: tableName,
+    });
 
-export async function update(tableName, params) {
-  const response = await AWS.dynamodb.updateTable({
-    TableName: tableName,
-    ...params,
-  });
+    return response;
+  }
 
-  return response;
+  async update(tableName, params) {
+    const response = await this.AWS.dynamodb.updateTable({
+      TableName: tableName,
+      ...params,
+    });
+
+    return response;
+  }
 }

--- a/server/src/validators/item.validators.js
+++ b/server/src/validators/item.validators.js
@@ -1,6 +1,8 @@
 import Joi from "joi";
-import * as TableService from "../services/table.service";
 import { scan, destroy, query } from "../schemas/item.joi";
+import TableServiceProvider from "../services/table.service";
+
+const TableService = new TableServiceProvider();
 
 export function validateScan(req, _res, next) {
   const { error } = scan.validate(req.body);


### PR DESCRIPTION
### Description
chore: procedural -> object oriented to support multiple DynamoDB instance 
- TableService -> class TableServiceProvider
- ItemService -> class ItemServiceProvider

### Related Issue
- https://github.com/kritish-dhaubanjar/dynamodb-dashboard/pull/179

### Motivation and Context
- Use of a single `AWS` prevents using the TableService & ItemService outside the instance.
- eg: To read dynamodb database from `https://dynamodb.us-east-2.amazonaws.com` and restore it into `http://localhost:8000` would require a pair of AWS Dynamodb instance. 
- To solve this, an `AWS` instance can now be injected into service and used normally.

eg:
```javascript
const TableService_1 = new TableServiceProvider(AWS_local)
const TableService_2 = new TableServiceProvider(AWS_remote)

TableService_1.all() // would read local dynamodb
TableService_2.all() // would read remote dynamodb
```

### How Has This Been Tested?
- 

### Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

