### PR TITLE
Add default value for AWS-Region and AWS-Endpoint for Restore Tables

### DIFF
--- a/app/src/views/table/RestoreTables.vue
+++ b/app/src/views/table/RestoreTables.vue
@@ -369,7 +369,7 @@ const progress = reactive({
 });
 
 const credentials = reactive({
-  AWS_REGION: "",
+  AWS_REGION: "us-west-2",
   AWS_ENDPOINT: "https://dynamodb.us-west-2.amazonaws.com",
   AWS_ACCESS_KEY_ID: "",
   AWS_SESSION_TOKEN: "",

--- a/app/src/views/table/RestoreTables.vue
+++ b/app/src/views/table/RestoreTables.vue
@@ -370,7 +370,7 @@ const progress = reactive({
 
 const credentials = reactive({
   AWS_REGION: "",
-  AWS_ENDPOINT: "",
+  AWS_ENDPOINT: "https://dynamodb.us-west-2.amazonaws.com",
   AWS_ACCESS_KEY_ID: "",
   AWS_SESSION_TOKEN: "",
   AWS_SECRET_ACCESS_KEY: "",
@@ -403,7 +403,7 @@ const explore = async () => {
 const sseOnMessageHandler = (sse, { data }) => {
   const { event, tableName, error } = JSON.parse(data);
 
-  if(event === 'END'){
+  if (event === "END") {
     return sse.close();
   }
 
@@ -419,15 +419,18 @@ const sseOnMessageHandler = (sse, { data }) => {
     progress.done.push(tableName);
     progress.queue = progress.queue.filter((e) => e !== tableName);
   }
-}
+};
 
 const restore = async () => {
   progress.failed = [];
   progress.done = [];
   progress.queue = localTables.value;
 
-  const uid = generateString(32)
-  const eventSourceURL = interpolate(`${axios.defaults.baseURL}${ROUTES.DATABASE.STREAM}`, { uid });
+  const uid = generateString(32);
+  const eventSourceURL = interpolate(
+    `${axios.defaults.baseURL}${ROUTES.DATABASE.STREAM}`,
+    { uid }
+  );
 
   const sse = new EventSource(eventSourceURL);
   sse.onmessage = (payload) => sseOnMessageHandler(sse, payload);


### PR DESCRIPTION
### Description
Add default value for AWS-Region and AWS-Endpoint for Restore Tables

**This file also had some prettier lint issues which got fixed automatically, recommend adding prettier to be run on pre-commit**

### Motivation and Context
We've needed to update the default setting for the AWS Region and AWS Endpoint to us-west-2, which has been a bit difficult to change due to long values. This update only affects the initial setting, but users can still choose their preferred region and endpoint.

### Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

#### Default value Persisting
https://github.com/kritish-dhaubanjar/dynamodb-dashboard/assets/15843175/24c2e635-de98-48a4-b24b-b57f7dafee45


#### Changing value to other region

https://github.com/kritish-dhaubanjar/dynamodb-dashboard/assets/15843175/209fbf12-59b4-40ad-b1bb-af951144e54c

