### PR TITLE
Set up Docker Hub publishing as a GitHub Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,119 @@
+# This automatically builds a multi-arch image and pushes it to Docker Hub
+# whenever a new release is published.
+#
+# Required settings:
+#
+# The `REGISTRY_IMAGE` GitHub Actions environment variable should contain
+# the image name, e.g. `kritishdhaubanjar/dynamodb-dashboard`.
+#
+# The `DOCKER_USERNAME` GitHub Actions secret should contain your Docker
+# Hub username.
+#
+# The `DOCKER_PASSWORD` GitHub Actions secret should contain a Docker Hub
+# access token with Read and Write permissions.
+
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.REGISTRY_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ vars.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        env:
+          PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.REGISTRY_IMAGE }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ vars.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ vars.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
### Description

This automatically builds a multi-arch image and pushes it to Docker Hub whenever a new release is published.

Required settings:

The `REGISTRY_IMAGE` GitHub Actions environment variable should contain the image name, e.g. `kritishdhaubanjar/dynamodb-dashboard`.

The `DOCKER_USERNAME` GitHub Actions secret should contain your Docker Hub username.

The `DOCKER_PASSWORD` GitHub Actions secret should contain a Docker Hub access token with Read and Write permissions.

### Related Issue

Fixes #618

### Motivation and Context

This automatically publishes amd64 and arm64 images to Docker Hub directly from GitHub. This means that people using arm64 (e.g. Apple Silicon users) can just pull the image and run it without any CPU emulation.

### How Has This Been Tested?

I published the image, then pulled it and ran it.

### Types of Changes
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
