### PR TITLE
remove-limit-on-number-of-table-restore: chore: remove limit on number of tables restore

### DIFF
--- a/server/src/services/database.service.js
+++ b/server/src/services/database.service.js
@@ -37,7 +37,7 @@ export default class DatabaseServiceProvider {
           await Promise.allSettled([this.TARGET.TableService.destroy(tableName)]);
           await this.TARGET.TableService.create(constructSchema(Table));
 
-          const params = { Limit: 100 };
+          const params = {};
           const schema = Table.KeySchema.map(({ AttributeName }) => AttributeName);
 
           do {


### PR DESCRIPTION
### Description
remove limit on number of tables to restore

### Related Issue
None

### Motivation and Context
If there is more than 100 tables in DB, it can't be restored due to limitations. 

### How Has This Been Tested?

### Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

