### PR TITLE
Fix  Partition key value is required persists even when the key is entered #688 

### DIFF
--- a/app/src/components/app/table-filter.vue
+++ b/app/src/components/app/table-filter.vue
@@ -621,7 +621,9 @@
   watch(
     () => parameters.keys.pk.value,
     async () => {
-      if (!errors.keys.pk.value.length) {
+      const hasError = Boolean(Object.keys(errors.keys.pk.value).length);
+
+      if (!hasError) {
         return;
       }
 


### PR DESCRIPTION
### Description
 Partition key value is required persists even when the key is entered #688 

### Related Issue
fixes #688 

### Motivation and Context
Why is this change required? What problem does it solve?

### How Has This Been Tested?
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

### Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

