### PR TITLE
Chore/event-based-restore: Implement event based restore to restore tables faster. 

### DIFF
--- a/app/src/constants/event.ts
+++ b/app/src/constants/event.ts
@@ -1,0 +1,6 @@
+export const EVENTS = {
+  END: "END",
+  ACTIVE: "ACTIVE",
+  FAILED: "FAILED",
+  SUCCESS: "SUCCESS",
+};

--- a/app/src/constants/status.ts
+++ b/app/src/constants/status.ts
@@ -1,0 +1,6 @@
+export const STATUS = {
+  ACTIVE: "active",
+  PENDING: "pending",
+  DONE: "done",
+  FAILED: "failed",
+};

--- a/app/src/views/table/RestoreTables.vue
+++ b/app/src/views/table/RestoreTables.vue
@@ -492,8 +492,6 @@
       toast.message = error.response?.data?.message ?? error.message;
       const toastEl = new bootstrap.Toast(toastRef.value, { delay: 1000 });
       setTimeout(() => toastEl.show(), 0);
-    } finally {
-      progress.queue = [];
     }
   };
 

--- a/server/src/constants/dynamodb.js
+++ b/server/src/constants/dynamodb.js
@@ -8,4 +8,4 @@ export const ProvisionedThroughput = {
   WriteCapacityUnits: 1,
 };
 
-export const QUEUE_SIZE = 7; // 'cause 7 is a lucky number ;) (and it's a prime number)
+export const POOL_SIZE = 7; // 'cause 7 is a lucky number ;) (and it's a prime number)

--- a/server/src/constants/dynamodb.js
+++ b/server/src/constants/dynamodb.js
@@ -7,3 +7,5 @@ export const ProvisionedThroughput = {
   ReadCapacityUnits: 1,
   WriteCapacityUnits: 1,
 };
+
+export const QUEUE_SIZE = 7; // 'cause 7 is a lucky number ;) (and it's a prime number)

--- a/server/src/constants/event.js
+++ b/server/src/constants/event.js
@@ -1,5 +1,6 @@
 export const EVENTS = {
   END: "END",
+  ACTIVE: "ACTIVE",
   FAILED: "FAILED",
   SUCCESS: "SUCCESS",
   RESTORE_TABLE: "RESTORE_TABLE",

--- a/server/src/constants/event.js
+++ b/server/src/constants/event.js
@@ -1,5 +1,6 @@
 export const EVENTS = {
+  END: "END",
   FAILED: "FAILED",
   SUCCESS: "SUCCESS",
-  END: "END",
+  RESTORE_TABLE: "RESTORE_TABLE",
 };

--- a/server/src/controllers/database.controller.js
+++ b/server/src/controllers/database.controller.js
@@ -45,8 +45,6 @@ export async function restore(req, res, next) {
     const DatabaseService = new DatabaseServiceProvider(AWS, credentials);
     const data = await DatabaseService.restore(tableNames, uid, eventEmitter);
 
-    eventEmitter.emit(EVENTS.END, uid);
-
     res.json(data);
   } catch (error) {
     next(error);

--- a/server/src/controllers/database.controller.js
+++ b/server/src/controllers/database.controller.js
@@ -32,6 +32,7 @@ export async function stream(req, res, _next) {
     res.write(`data: ${JSON.stringify({ ...data, event })}\n\n`);
   };
 
+  eventEmitter.on(EVENTS.ACTIVE, (id, payload) => emit(id, EVENTS.ACTIVE, payload));
   eventEmitter.on(EVENTS.SUCCESS, (id, payload) => emit(id, EVENTS.SUCCESS, payload));
   eventEmitter.on(EVENTS.FAILED, (id, payload) => emit(id, EVENTS.FAILED, payload));
   eventEmitter.on(EVENTS.END, (id) => emit(id, EVENTS.END));

--- a/server/src/services/database.service.js
+++ b/server/src/services/database.service.js
@@ -4,7 +4,7 @@ import { EVENTS } from "../constants/event";
 
 import ItemServiceProvider from "./item.service";
 import TableServiceProvider from "./table.service";
-import { QUEUE_SIZE } from "../constants/dynamodb";
+import { POOL_SIZE } from "../constants/dynamodb";
 
 export default class DatabaseServiceProvider {
   constructor(_AWS_, credentials) {
@@ -31,10 +31,12 @@ export default class DatabaseServiceProvider {
 
   async restore(tableNames = [], uid, eventEmitter) {
     const cloneTableNames = [...tableNames];
-    const queuedTables = cloneTableNames.splice(0, QUEUE_SIZE)
+    const queuedTables = cloneTableNames.splice(0, POOL_SIZE)
     let activeTableCount = queuedTables.length
 
     const restoreTable = async (tableName) => {
+      eventEmitter.emit(EVENTS.ACTIVE, uid, { tableName })
+
       try {
         await TableServiceProvider.restore(tableName, this);
         eventEmitter.emit(EVENTS.SUCCESS, uid, { tableName });


### PR DESCRIPTION
### Description
Implement event based restore to restore tables faster. 

#### Other improvements
- [x] Use Map to store the table restore status instead of maintaining array.
- [x] Add the pending state to represent the awaiting state for table that are waiting for pool allocation to start the backup process.

### Motivation and Context
Using `Promise.all` is failing for project having a lots of table. So instead of restoring all table at once, defined a POOL_SIZE (7 for now), so that POOL_SIZE number of table are being restored at a time.

