### PR TITLE
chore: add json replacer for bigint values in response

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,6 +17,8 @@ app.use(cors({ origin: "*" }));
 app.use(morgan("dev"));
 app.use(express.json());
 
+app.set('json replacer', (_key, value) => typeof value === 'bigint' ? value.toString() : value);
+
 // api
 app.use("/dynamodb/api", routes);
 


### PR DESCRIPTION
fix #1214 

### Description

Fixed server crashes caused by JSON.stringify() failing on BigInt values by converting them to strings. The server now responds correctly.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json

### Related Issue
- #1214 

### Motivation and Context
Why is this change required? What problem does it solve?

The goal was simply to make sure values show up and the app keeps running.

ex) 
An item with the following bigInt would crash on response
```js
const data = await ItemService.fetch(OPERATIONS.SCAN, tableName, req.body);
console.log(data)
/**
output: 
{
  Items: [ { bigint: 1742866083515030379n, pk: 'TEST' } ],
  Count: 1,
  ScannedCount: 1,
  LastEvaluatedKey: undefined
}
*/
res.json(data); // !!!!
```


### How Has This Been Tested?

1. create `tmp` table
![2025-04-12 110810](https://github.com/user-attachments/assets/3f0cab7f-f08c-4c09-b102-973182797525)

2. put a item
```
aws dynamodb put-item  \
    --table-name tmp \
    --item '{"pk": {"S": "TEST"}, "bigint": {"N": "1742866083515030379"}}' \
    --endpoint-url http://localhost:8000
```

3. views
![2025-04-12 110915](https://github.com/user-attachments/assets/42208b7a-59b9-4cc7-a5f5-dc5658e47be8)


### Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if appropriate):

