### PR TITLE
Shut down gracefully on SIGTERM and SIGINT

### DIFF
--- a/server/src/bin/server.js
+++ b/server/src/bin/server.js
@@ -43,7 +43,19 @@ export default ({ port, host, debug, prefix }) => {
 
   app.use(errorHandler);
 
-  app.listen(port, host, () => {
+  const server = app.listen(port, host, () => {
     console.info(`dynamodb-dashboard started at: ${URL}\n`);
+  });
+
+  process.on("SIGTERM", () => {
+    server.close(() => {
+      process.exit(0);
+    });
+  });
+
+  process.on("SIGINT", () => {
+    server.close(() => {
+      process.exit(0);
+    });
   });
 };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,3 +37,15 @@ app.use(errorHandler);
 const server = app.listen(4567, () => {
   console.info(`dynamodb-dashboard started at: http://127.0.0.1:4567/dynamodb\n`);
 });
+
+process.on("SIGTERM", () => {
+  server.close(() => {
+    process.exit(0);
+  });
+});
+
+process.on("SIGINT", () => {
+  server.close(() => {
+    process.exit(0);
+  });
+});


### PR DESCRIPTION
Express doesn’t handle termination signals by default. This means that when Docker tries to stop the container, it will hang for ten seconds before killing the process.

Here we add handlers for both signals and shut down gracefully, resulting in Docker being able to shut down the container immediately.

See: https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html
