### PR TITLE
fix: support binary partition keys in item navigation and lookup

### DIFF
--- a/app/src/components/app/item-list.vue
+++ b/app/src/components/app/item-list.vue
@@ -168,15 +168,14 @@
                 data-bs-toggle="tooltip"
                 data-bs-placement="top"
                 data-bs-title="Copy to clipboard"
-                @click="copy(item[headers[0]])"
+                @click.stop="copy(formatCellDisplay(item[headers[0]]))"
               ></i>
 
-              <!--  -->
               <RouterLink
                 :to="handleItem(item)"
                 class="card-link text-decoration-none"
               >
-                {{ item[headers[0]] }}
+                {{ formatCellDisplay(item[headers[0]]) }}
               </RouterLink>
             </td>
 
@@ -239,7 +238,7 @@
               v-for="(key, index) in headers.slice(1)"
               :key="key"
             >
-              <div>{{ item[key] }}</div>
+              <div>{{ formatCellDisplay(item[key]) }}</div>
             </td>
           </tr>
         </tbody>
@@ -338,6 +337,7 @@
   import * as bootstrap from "bootstrap";
   import { useRouter } from "vue-router";
   import { destroyItems, truncateItems } from "@/services/item";
+  import { formatCellDisplay, serializeKeyForQuery } from "@/utils/binary";
   import { openSearchPanel } from "@codemirror/search";
   import codeMirrorConfig from "@/views/items/codeMirrorConfig";
   import { computed, inject, onMounted, ref, watch, watchEffect, reactive, nextTick } from "vue";
@@ -521,10 +521,10 @@
       params: { tableName },
       query: {
         ...(pk.value && {
-          [pk.value.AttributeName]: item[pk.value.AttributeName],
+          [pk.value.AttributeName]: serializeKeyForQuery(item[pk.value.AttributeName]),
         }),
         ...(sk.value && {
-          [sk.value.AttributeName]: item[sk.value.AttributeName],
+          [sk.value.AttributeName]: serializeKeyForQuery(item[sk.value.AttributeName]),
         }),
       },
     };
@@ -595,8 +595,17 @@
       const payload = [];
 
       selectedItems.value.forEach((item) => {
-        const { query } = handleItem(item);
-        payload.push(query);
+        const key: Record<string, unknown> = {};
+
+        if (pk.value) {
+          key[pk.value.AttributeName] = item[pk.value.AttributeName];
+        }
+
+        if (sk.value) {
+          key[sk.value.AttributeName] = item[sk.value.AttributeName];
+        }
+
+        payload.push(key);
       });
 
       await destroyItems(tableName, payload);
@@ -612,8 +621,8 @@
     modal.value.hide();
   };
 
-  const copy = (partitionKey) => {
-    navigator.clipboard.writeText(partitionKey);
+  const copy = (value: string) => {
+    navigator.clipboard.writeText(value);
   };
 
   const offcanvas = (item) => {

--- a/app/src/utils/binary.ts
+++ b/app/src/utils/binary.ts
@@ -1,0 +1,38 @@
+export function isBinaryLikeObject(value: unknown): value is Record<string, number> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const keys = Object.keys(value);
+
+  if (keys.length === 0) {
+    return false;
+  }
+
+  return keys.every((key) => /^\d+$/.test(key) && Number.isInteger(value[key]) && value[key] >= 0 && value[key] <= 255);
+}
+
+export function serializeKeyForQuery(value: unknown): string | number | boolean {
+  if (!isBinaryLikeObject(value)) {
+    return value as string | number | boolean;
+  }
+
+  const bytes = Object.keys(value)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map((index) => value[String(index)]);
+
+  return btoa(String.fromCharCode(...bytes));
+}
+
+export function formatCellDisplay(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}

--- a/server/src/controllers/item.controller.js
+++ b/server/src/controllers/item.controller.js
@@ -1,5 +1,6 @@
 import { OPERATIONS } from "../constants/dynamodb";
 import { isPartialMatchWith } from "../utils/object";
+import { normalizeKeys } from "../utils/dynamodb";
 import ItemServiceProvider from "../services/item.service";
 
 const ItemService = new ItemServiceProvider();
@@ -7,7 +8,8 @@ const ItemService = new ItemServiceProvider();
 export async function get(req, res, next) {
   try {
     const { tableName } = req.params;
-    const data = await ItemService.get(tableName, req.body);
+    const keys = normalizeKeys(req.body, req.attributeDefinitions);
+    const data = await ItemService.get(tableName, keys);
 
     if (!data.Item) {
       res.status(404);
@@ -62,7 +64,12 @@ export async function truncate(req, res, next) {
 export async function destroy(req, res, next) {
   try {
     const { tableName } = req.params;
-    const data = await ItemService.destroy(tableName, req.body);
+    const items = req.body.map((item) => ({
+      DeleteRequest: {
+        Key: normalizeKeys(item.DeleteRequest.Key, req.attributeDefinitions),
+      },
+    }));
+    const data = await ItemService.destroy(tableName, items);
     res.json(data);
   } catch (error) {
     next(error);
@@ -83,15 +90,19 @@ export async function update(req, res, next) {
   try {
     const { ref, body } = req.body;
     const { tableName } = req.params;
+    const normalizedBody = {
+      ref: normalizeKeys(ref, req.attributeDefinitions),
+      body,
+    };
 
-    const isReplace = isPartialMatchWith(ref, body, req.schema);
+    const isReplace = isPartialMatchWith(normalizedBody.ref, body, req.schema);
 
     let data;
 
     if (isReplace) {
-      data = await ItemService.update(tableName, req.schema, req.body);
+      data = await ItemService.update(tableName, req.schema, normalizedBody);
     } else {
-      data = await ItemService.transactUpdate(tableName, req.schema, req.body);
+      data = await ItemService.transactUpdate(tableName, req.schema, normalizedBody);
     }
 
     res.json(data);

--- a/server/src/utils/dynamodb.js
+++ b/server/src/utils/dynamodb.js
@@ -108,3 +108,62 @@ export function deserialize(source = {}, object = {}) {
 
   return object;
 }
+
+function isBinaryLikeObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const keys = Object.keys(value);
+
+  if (keys.length === 0) {
+    return false;
+  }
+
+  return keys.every((key) => /^\d+$/.test(key) && Number.isInteger(value[key]) && value[key] >= 0 && value[key] <= 255);
+}
+
+function toBinary(value) {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    return new Uint8Array(value);
+  }
+
+  if (typeof value === "string") {
+    return new Uint8Array(Buffer.from(value, "base64"));
+  }
+
+  if (isBinaryLikeObject(value)) {
+    const bytes = Object.keys(value)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((index) => value[String(index)]);
+
+    return new Uint8Array(bytes);
+  }
+
+  return value;
+}
+
+export function normalizeKeys(keys = {}, attributeDefinitions = []) {
+  const output = { ...keys };
+
+  attributeDefinitions.forEach(({ AttributeName, AttributeType }) => {
+    if (!Object.hasOwn(output, AttributeName)) {
+      return;
+    }
+
+    if (AttributeType === "B") {
+      output[AttributeName] = toBinary(output[AttributeName]);
+    }
+
+    if (AttributeType === "N") {
+      output[AttributeName] = Number(output[AttributeName]);
+    }
+  });
+
+  return output;
+}

--- a/server/src/validators/item.validators.js
+++ b/server/src/validators/item.validators.js
@@ -67,7 +67,7 @@ export async function validateTruncate(req, _res, next) {
   }
 }
 
-export function validateDelete(req, _res, next) {
+export async function validateDelete(req, _res, next) {
   const { error } = destroy.validate(req.body);
 
   if (error) {
@@ -76,7 +76,16 @@ export function validateDelete(req, _res, next) {
     return;
   }
 
-  next();
+  const { tableName } = req.params;
+
+  try {
+    const { Table } = await TableService.describe(tableName);
+    req.attributeDefinitions = Table.AttributeDefinitions;
+
+    next();
+  } catch (err) {
+    next(err);
+  }
 }
 
 export async function validateCreate(req, _res, next) {
@@ -100,6 +109,7 @@ export async function validateCreate(req, _res, next) {
     }
 
     req.schema = Object.keys(schema);
+    req.attributeDefinitions = Table.AttributeDefinitions;
 
     next();
   } catch (error) {
@@ -132,6 +142,7 @@ export async function validateUpdate(req, _res, next) {
     }
 
     req.schema = Object.keys(schema);
+    req.attributeDefinitions = Table.AttributeDefinitions;
 
     next();
   } catch (error) {


### PR DESCRIPTION
# fix: support binary partition keys in item navigation and lookup

## Summary

Fix item navigation and key-based operations for tables with **Binary (`B`) partition/sort keys**.

Binary attributes were serialized as byte-index objects (e.g. `{"0":174,"1":160,...}`). When used in Vue Router query params, they became `[object Object]`, and DynamoDB API calls failed with `ValidationException: Type mismatch for key`.

## Description

### Problem

When DynamoDB returns Binary attributes, the existing `serialize()` logic converts `Uint8Array` into plain objects with numeric keys. This causes two issues:

1. **UI navigation** - Clicking a binary partition key builds a route like `/edit-item?U=[object+Object]`.
2. **API operations** - `get`, `delete`, and `update` send invalid key shapes to DynamoDB.

### Solution

- **Client (`app`)**
  - Keep displaying raw serialized data in the table (`JSON.stringify` for object values).
  - Encode binary keys as **base64** only when building router query params (`serializeKeyForQuery`).
  - Pass raw key objects when deleting items (server handles normalization).

- **Server (`server`)**
  - Add `normalizeKeys()` to convert Binary keys from base64 strings or byte-index objects into `Uint8Array` before DynamoDB calls.
  - Apply normalization in `get`, `destroy`, and `update` controllers.
  - Load `AttributeDefinitions` in validators so key types are known at request time.

### Changed files

| File | Change |
|------|--------|
| `app/src/utils/binary.ts` | Binary detection, base64 URL encoding, cell display helper |
| `app/src/components/app/item-list.vue` | Display raw values; encode binary keys in router query |
| `server/src/utils/dynamodb.js` | `normalizeKeys()` for Binary/Number keys |
| `server/src/controllers/item.controller.js` | Normalize keys before get/delete/update |
| `server/src/validators/item.validators.js` | Attach `attributeDefinitions` to request |

## Related Issue

N/A - no existing issue filed. Happy to open one if preferred.

### Steps to reproduce (before fix)

1. Create or use a table with a Binary (`B`) partition key.
2. Insert items and open the table in the dashboard.
3. Click a partition key link.
4. URL shows `?U=[object+Object]`; edit page fails with `ValidationException: Type mismatch for key`.

## Motivation and Context

Binary keys are valid in DynamoDB but were not handled end-to-end in the dashboard. The API layer already serializes Binary as byte-index objects for JSON transport; the fix bridges that representation to valid router query params and DynamoDB key types without changing the displayed raw data format.

## How Has This Been Tested?

### Environment

- OS: Windows 10
- DynamoDB Local in Docker (`AWS_ENDPOINT=http://localhost:4100`)
- App: `yarn dev` in `server` and `app`
- Test table: `Example_Accounts` with Binary partition key `U` (`AttributeType: B`)

### Manual tests

- [x] Scan/list items - binary keys display as raw JSON, e.g. `{"0":174,"1":160,...}`
- [x] Click partition key - URL uses base64, e.g. `?U=rqC%2BgM0KRJasJ...`, not `[object Object]`
- [x] Edit item page loads successfully via `POST .../items/get`
- [x] Delete selected items with binary keys works
- [x] String/Number partition keys still navigate and load correctly (no regression)

### API verification

```bash
# get with base64 key - success
POST /dynamodb/api/tables/Example_Accounts/items/get
Body: {"U":"<base64>"}

# get with byte-index object - success
POST /dynamodb/api/tables/Example_Accounts/items/get
Body: {"U":{"0":174,"1":160,...}}
```

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
